### PR TITLE
build: add a simple check for certificates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,10 @@ PREFIX ?= /usr/local
 SYSCONFDIR ?= $(PREFIX)/etc
 
 
-all:
+all: check
+
+check:
+	find etc-conf -name '*.pem' -print | xargs -t -I{} openssl x509 -in {} -noout -checkend 0
 
 install:
 	install -d $(DESTDIR)$(SYSCONFDIR)/rhsm/ca

--- a/subscription-manager-rhsm-certificates.spec
+++ b/subscription-manager-rhsm-certificates.spec
@@ -21,6 +21,7 @@ Source0: %{name}-%{version}.tar.gz
 BuildArch: noarch
 
 BuildRequires: make
+BuildRequires: openssl
 
 %description
 This package contains certificates required for communicating with the REST interface
@@ -37,6 +38,9 @@ and to receive access to content.
 %make_install \
     PREFIX=%{_prefix} \
     SYSCONFDIR=%{_sysconfdir}
+
+%check
+make check
 
 %files
 %license COPYING


### PR DESCRIPTION
Add a simple `check` target that runs openssl to verify all the *.pem
files in the `etc-conf` subdirectory.

Extend the packaging bits to run the new target at `%check` time; the
`openssl` BuildRequires is added for the `openssl` command line tool.

Suggested by Petr Menšík, thanks!