### PR TITLE
spec: drop Group from non-SUSE distros

### DIFF
--- a/subscription-manager-rhsm-certificates.spec
+++ b/subscription-manager-rhsm-certificates.spec
@@ -7,7 +7,6 @@ URL: https://www.candlepinproject.org/
 Group: Development/Libraries/Python
 License: GPL-2.0
 %else
-Group: Development/Libraries
 License: GPLv2
 %endif
 


### PR DESCRIPTION
Group is no more needed on Red Hat distros for some years already:
https://fedoraproject.org/wiki/Changes/Remove_Group_Tag