### PR TITLE
CI updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,19 +44,10 @@ jobs:
         dnf config-manager --set-enabled crb
         dnf install -y epel-release epel-next-release
 
-    - name: Install tito (packages)
-      if: "${{ !endsWith(matrix.container, 'stream9') }}"
+    - name: Install tito
       run: |
         dnf --setopt install_weak_deps=False install -y \
             tito
-
-    - name: Install tito (pip)
-      if: ${{ endsWith(matrix.container, 'stream9') }}
-      run: |
-        dnf --setopt install_weak_deps=False install -y \
-            python3-pip \
-            python3-setuptools
-        pip install https://github.com/rpm-software-management/tito/archive/refs/tags/tito-0.6.20-1.tar.gz
 
     - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   pull_request:
-  push:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,12 @@ jobs:
 
     - uses: actions/checkout@v3
 
+    # This step is required so Tito can properly read git history
+    # See https://github.com/actions/checkout/issues/766
+    - name: Trust git repository path
+      run: |
+        git config --global --add safe.directory '*'
+
     - name: Install RPM build dependencies
       run: |
         dnf --setopt install_weak_deps=False builddep -y \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,7 @@ jobs:
       if: ${{ endsWith(matrix.container, 'stream9') }}
       run: |
         dnf config-manager --set-enabled crb
-        dnf install -y \
-            https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm \
-            https://dl.fedoraproject.org/pub/epel/epel-next-release-latest-9.noarch.rpm
+        dnf install -y epel-release epel-next-release
 
     - name: Install tito (packages)
       if: "${{ !endsWith(matrix.container, 'stream9') }}"


### PR DESCRIPTION
- install EPEL packages from repos
- tito is installable also on EL9 now, so install it always from repos
- make sure `git` can work on the checked out repo
- do not run jobs on push