### PR TITLE
chore: Remove CentOS Stream 8 from our CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
         container:
           - "registry.fedoraproject.org/fedora:latest"
           - "registry.fedoraproject.org/fedora:rawhide"
-          - "quay.io/centos/centos:stream8"
           - "quay.io/centos/centos:stream9"
     container:
       image: ${{ matrix.container }}
@@ -43,12 +42,6 @@ jobs:
         name=${name##*/}
         name=${name//:/-}
         echo "name=${name}" >> $GITHUB_OUTPUT
-
-    - name: Setup EPEL 8
-      if: ${{ endsWith(matrix.container, 'stream8') }}
-      run: |
-        dnf config-manager --set-enabled powertools
-        dnf install -y epel-release epel-next-release
 
     - name: Setup EPEL 9
       if: ${{ endsWith(matrix.container, 'stream9') }}


### PR DESCRIPTION
* The CentOS Stream 8 is EOL and it does not make sense to try to use it