### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     # at 8:00 every 1st of the month
     - cron: 0 8 1 * *
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: "📦 Build & install"


### PR DESCRIPTION
Potential fix for [https://github.com/candlepin/subscription-manager-rhsm-certificates/security/code-scanning/1](https://github.com/candlepin/subscription-manager-rhsm-certificates/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root in `.github/workflows/ci.yml`, directly under the `on:` triggers (before `jobs:`), with the minimum required scope:

- `contents: read`

_Suggested fixes powered by Copilot Autofix._
